### PR TITLE
index sort

### DIFF
--- a/src/fhir/search.litcoffee
+++ b/src/fhir/search.litcoffee
@@ -169,6 +169,34 @@ To build search query we need to
         hsql.where = expr
       hsql
 
+    _order_sql = (plv8, idx, query)->
+      unless query.resourceType
+        throw new Error("Expected query.resourceType attribute")
+
+      next_alias = mk_alias()
+
+      alias = next_alias()
+
+      expr = parser.parse(query.resourceType, query.queryString || "")
+      expr = expand.expand(idx, expr)
+      expr = normalize_operators(expr)
+
+      ordering = ''
+      if expr.sort
+        ordering = order_hsql(alias, expr.sort)
+
+      hsql =
+        select: ':*'
+        from: ['$alias', ['$q', namings.table_name(plv8, expr.query)], alias]
+        where: expr.where
+        order: ordering
+
+      if expr.joins
+        hsql.join = lang.mapcat expr.joins, (x)->
+          mk_join(plv8, alias, next_alias, x)
+
+      {hsql: hsql, query: expr}
+
     _search_sql = (plv8, idx, query)->
         unless query.resourceType
           throw new Error("Expected query.resourceType attribute")
@@ -334,6 +362,23 @@ awaiting query.resourceType and query.name - name of parameter
     fhir_index_parameter.plv8_signature = ['json', 'json']
     exports.fhir_index_parameter = fhir_index_parameter
 
+`fhir_index_order(query)` function creates index for parameter sort,
+awaiting query.resourceType and query.name - name of parameter
+
+    fhir_index_order = (plv8, query)->
+      metas = expand_parameter(plv8, query)
+      h = ensure_handler(plv8, metas)
+      idx_infos = h.index_order(plv8, metas)
+
+      for idx_info in idx_infos
+       if pg_meta.index_exists(plv8, idx_info.name)
+         {status: 'error', message: "Index #{idx_info.name} already exists"}
+       else
+         utils.exec(plv8, idx_info.ddl)
+         {status: 'ok', message: "Index #{idx_info.name} was created"}
+
+    fhir_index_order.plv8_signature = ['json', 'json']
+    exports.fhir_index_order = fhir_index_order
 
     fhir_unindex_parameter = (plv8, query)->
       meta = expand_parameter(plv8, query)
@@ -348,6 +393,20 @@ awaiting query.resourceType and query.name - name of parameter
 
     fhir_unindex_parameter.plv8_signature = ['json', 'json']
     exports.fhir_unindex_parameter = fhir_unindex_parameter
+
+    fhir_unindex_order = (plv8, query)->
+      meta = expand_parameter(plv8, query)
+      h = ensure_handler(plv8, meta)
+      idx_infos = h.index_order(plv8, meta)
+      for idx_info in idx_infos
+        if pg_meta.index_exists(plv8, idx_info.name)
+          utils.exec(plv8, drop: 'index', name: ":#{idx_info.name}")
+          {status: 'ok', message: "Index #{idx_info.name} was dropped"}
+        else
+          {status: 'error', message: "Index #{idx_info.name} does not exist"}
+
+    fhir_unindex_order.plv8_signature = ['json', 'json']
+    exports.fhir_unindex_order = fhir_unindex_order
 
 ## Maintains
 

--- a/src/fhir/search_common.coffee
+++ b/src/fhir/search_common.coffee
@@ -1,0 +1,52 @@
+custom_expr = (meta, tbl, opname)->
+  from = if tbl then ['$q',":#{tbl}", ':resource'] else ':resource'
+
+  ["$#{opname}"
+   ['$cast', from, ':json']
+   ['$cast', ['$quote', JSON.stringify(meta.path)], ':json']
+   ['$quote', meta.elementType]]
+
+order_expr_custom = (func_name)->
+  (tbl, meta)->
+    op = if meta.operator == 'desc' then '$desc' else '$asc'
+    [op, custom_expr(meta, tbl, func_name)]
+
+order_expression = (func_name, SUPPORTED_TYPES)->
+  order_expr = order_expr_custom(func_name)
+  (tbl, meta)->
+    unless SUPPORTED_TYPES.indexOf(meta.elementType) > -1
+      throw new Error("String Search: unsuported type #{JSON.stringify(meta)}")
+    order_expr(tbl, meta)
+
+extract_expr_custom = (func_name)->
+  (meta, tbl)->
+    custom_expr(meta, tbl, func_name)
+
+
+get_search_functions = (obj) ->
+  extract = obj.extract
+  sort = obj.sort
+  SUPPORTED_TYPES = obj.SUPPORTED_TYPES
+  order_expr = order_expr_custom(sort)
+  {
+    order_expression: order_expression(sort, SUPPORTED_TYPES)
+    extract_expr: extract_expr_custom(extract)
+    index_order : (plv8, metas)->
+      meta = metas[0]
+      idx_name = "#{meta.resourceType.toLowerCase()}_#{meta.name.replace('-','_')}_order"
+
+      exprs = [order_expr(meta.resourceType.toLowerCase(), meta)]
+
+      [
+        name: idx_name
+        ddl:
+          create: 'index'
+          name:  idx_name
+          using: ':BTREE'
+          on: meta.resourceType.toLowerCase()
+          expression: exprs
+      ]
+
+  }
+
+exports.get_search_functions = get_search_functions

--- a/src/fhir/search_quantity.litcoffee
+++ b/src/fhir/search_quantity.litcoffee
@@ -22,9 +22,18 @@ TODO: later we will add some support for units convertion and search in canonica
 
     token_s = require('./search_token')
     number_s = require('./search_number')
+    search_common = require('./search_common')
 
     SUPPORTED_TYPES = ['Quantity']
     OPERATORS = ['eq', 'lt', 'le', 'gt', 'ge', 'missing']
+
+    sf = search_common.get_search_functions({
+      extract:'fhir_extract_as_number',
+      sort:'fhir_extract_as_number',
+      SUPPORTED_TYPES:SUPPORTED_TYPES
+    })
+    exports.index_order = sf.index_order
+
 
     identity = (x)-> x
 
@@ -52,7 +61,7 @@ TODO: later we will add some support for units convertion and search in canonica
 
     exports.handle = (tbl, meta, value)->
       unless SUPPORTED_TYPES.indexOf(meta.elementType) > -1
-        throw new Error("Quantity Search: unsuported type #{JSON.stringify(meta)}")
+        throw new Error("Quantity Search: unsupported type #{JSON.stringify(meta)}")
 
       unless OPERATORS.indexOf(meta.operator) > -1
         throw new Error("Quantity Search: Unsupported operator #{meta.operator}")

--- a/src/fhir/search_reference.litcoffee
+++ b/src/fhir/search_reference.litcoffee
@@ -80,7 +80,7 @@ Only equality operator is implemented.
 
     exports.handle = (tbl, meta, value)->
       unless SUPPORTED_TYPES.indexOf(meta.elementType) > -1
-        throw new Error("Reference Search: unsuported type #{JSON.stringify(meta)}")
+        throw new Error("Reference Search: unsupported type #{JSON.stringify(meta)}")
 
       op = OPERATORS[meta.operator]
 

--- a/src/honey.coffee
+++ b/src/honey.coffee
@@ -250,10 +250,10 @@ BUILTINS =
     res.push(")::jsonb")
   $asc: (res, [op, expr])->
     heval(res, expr)
-    res.push("ASC")
+    res.push("ASC NULLS LAST")
   $desc: (res, [op, expr])->
     heval(res, expr)
-    res.push("DESC")
+    res.push("DESC NULLS FIRST")
 
 
 CREATE_CLAUSES =

--- a/test/fhir/search/quantity_search.yaml
+++ b/test/fhir/search/quantity_search.yaml
@@ -1,7 +1,11 @@
 title: Quantity Search
 resources: ['Observation']
-indices:
-  - {resourceType: 'Observation', name: 'value-quantity'}
+# indices:
+#  - {resourceType: 'Observation', name: 'value-quantity'}
+
+
+index_order:
+  - query: {resourceType: "Observation", name: "value-quantity"}
 
 fixtures:
   - resourceType: 'Observation'
@@ -49,11 +53,13 @@ queries:
     total:  3
   - query: {resourceType: 'Observation', queryString:  '_sort=value-quantity'}
     total:  4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'obs-3'
   - query: {resourceType: 'Observation', queryString:  '_sort:desc=value-quantity'}
     total:  4
+    indexed_order: true
     probes:
       - path: ['entry', '3', 'resource', 'id']
         result: 'obs-3'

--- a/test/fhir/search/sort_search.yaml
+++ b/test/fhir/search/sort_search.yaml
@@ -12,9 +12,17 @@ fixtures:
   - {id: 'b', resourceType: 'Encounter', length: {value: 30}}
   - {id: 'a', resourceType: 'Encounter', length: {value: 40}}
 
+index_order:
+  - query: {resourceType: "Patient", name: "name"}
+  - query: {resourceType: "Patient", name: "birthdate"}
+  - query: {resourceType: "Patient", name: "gender"}
+  - query: {resourceType: "Encounter", name: "length"}
+
+
 queries:
   - query: {resourceType: 'Patient', queryString: '_sort=name'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'a'
@@ -22,6 +30,7 @@ queries:
         result: 'b'
   - query: {resourceType: 'Patient', queryString: '_sort:desc=name'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'd'
@@ -29,6 +38,7 @@ queries:
         result: 'c'
   - query: {resourceType: 'Patient', queryString: '_sort=birthdate'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'd'
@@ -36,6 +46,7 @@ queries:
         result: 'c'
   - query: {resourceType: 'Patient', queryString: '_sort:desc=birthdate'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'a'
@@ -43,23 +54,27 @@ queries:
         result: 'b'
   - query: {resourceType: 'Patient', queryString: '_sort=gender'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'd'
   - query: {resourceType: 'Patient', queryString: '_sort:desc=gender'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '3', 'resource', 'id']
         result: 'd'
 
   - query: {resourceType: 'Encounter', queryString: '_sort=length'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'd'
 
   - query: {resourceType: 'Encounter', queryString: '_sort:desc=length'}
     total: 4
+    indexed_order: true
     probes:
       - path: ['entry', '0', 'resource', 'id']
         result: 'a'


### PR DESCRIPTION
Added new pg public function fhir_index_order ( relates to #41  ) as an analogy to fhir_index_parameter.

fhir_index_order creates an index which is based on order by functions, the index is used for forward and backward btree search.

Added fhir_unindex_order function.

Added small fix inside fhir_sort_as_string that prevents calling  String.join method.

Null order is  now explicit when order by expressions are used

Changed some tests.

Some common code parts were moved from search_*.coffee  to search_common.coffee with minimum changes. 

I suppose that more complex requirements might need additional changes...

Please let me know If I forgot something or this needs some changes.
