### PR TITLE
Fix jsonb concatenation error in postgres 9.5.

### DIFF
--- a/src/benchmark.coffee
+++ b/src/benchmark.coffee
@@ -34,7 +34,7 @@ fhir_benchmark = (plv8, query)->
     """
     SELECT count(
              fhir_update_resource(
-               ('{"resource":' || temp_patients.data || '}')::json
+               ('{"resource":' || temp_patients.data::text || '}')::json
              )
            )
            FROM


### PR DESCRIPTION
```
     Error: ERROR:  Error: invalid input syntax for type json
DETAIL:  plv8_init() LINE 7081:       plv8.execute(benchmark.statement);
```

This appears to be due to the new jsonb concatenation operator in 9.5:

```
psql (9.5.3, server 9.4.8)

postgres=# select 'foo' || '"bar"'::jsonb;
 ?column?
----------
 foo"bar"
(1 row)
```

```
psql (9.5.3)

postgres=# select 'foo' || '"bar"'::jsonb;
ERROR:  invalid input syntax for type json
LINE 1: select 'foo' || '"bar"'::jsonb;
               ^
DETAIL:  Token "foo" is invalid.
CONTEXT:  JSON data, line 1: foo

```
